### PR TITLE
style(ExperienceCard): adjust layout and remove padding

### DIFF
--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/ExperienceCard.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/ExperienceCard.tsx
@@ -63,6 +63,8 @@ const TechList = styled.ul`
   display: flex;
   gap: 16px;
   align-items: center;
+  justify-content: space-between;
+  padding: 0;
 `;
 
 const TechEntry = styled.li`


### PR DESCRIPTION
Add justify-content: space-between to distribute items evenly in ExperienceCard and remove padding to align content more precisely. These changes improve the visual balance and spacing of the experience entries on the professional page.