### PR TITLE
Add whoami

### DIFF
--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/Biopic.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/Biopic.tsx
@@ -14,4 +14,7 @@ export default function Biopic() {
 
 const BiopicWrapper = styled.div`
   margin: auto;
+  line-height: 1.8;
+  text-align: justify;
+  text-indent: 2rem;
 `;

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/ProfessionalContent.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/ProfessionalContent.tsx
@@ -6,8 +6,8 @@ import Experience from './Experience/Experience';
 export default function ProfessionalContent() {
   return (
     <Wrapper>
-      <Experience />
       <Biopic />
+      <Experience />
       <PortFolio />
     </Wrapper>
   );

--- a/frontend/src/components/ProfessionalPage/ProfessionalPage.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalPage.tsx
@@ -1,6 +1,7 @@
 import Header from './Header/Header';
 import ProfessionalContent from './ProfessionalContent/ProfessionalContent';
-import SideMenu from './SideMenu/SideMenu';
+import SideMenu from './SideBar/SideMenu';
+import Whoami from './SideBar/Whoami';
 
 import { styled } from 'styled-components';
 
@@ -9,9 +10,10 @@ export default function ProfessionalPage() {
     <Wrapper>
       <Header />
       <ContentWrapper>
-        <SideMenuWrapper>
+        <SideBarWrapper>
+          <Whoami />
           <SideMenu />
-        </SideMenuWrapper>
+        </SideBarWrapper>
         <ProfessionalContentWrapper>
           <ProfessionalContent />
         </ProfessionalContentWrapper>
@@ -29,15 +31,19 @@ const Wrapper = styled.div`
 
 const ContentWrapper = styled.div`
   display: flex;
+  justify-content: center;
   align-items: start;
+  gap: 184px;
 `;
 
-const SideMenuWrapper = styled.div`
+const SideBarWrapper = styled.div`
   position: sticky;
   top: 0;
-  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 84px;
 `;
 
 const ProfessionalContentWrapper = styled.div`
-  flex: 1;
 `;

--- a/frontend/src/components/ProfessionalPage/SideBar/SideMenu.tsx
+++ b/frontend/src/components/ProfessionalPage/SideBar/SideMenu.tsx
@@ -18,7 +18,6 @@ const Nav = styled.nav`
   gap: 34px;
 
   height: 64px;
-  width: 450px;
   margin: 0 auto;
   padding: 0 34px;
 `;

--- a/frontend/src/components/ProfessionalPage/SideBar/Whoami.tsx
+++ b/frontend/src/components/ProfessionalPage/SideBar/Whoami.tsx
@@ -1,0 +1,32 @@
+import { styled } from 'styled-components';
+
+import { H1, H2, H3 } from 'components/Commons/Titles';
+
+export default function Whoami() {
+  return (
+    <Wrapper>
+      <Name>Emmanuel Guefif</Name>
+      <Title>Mid-level developer</Title>
+      <FormerTitle>Former elementary school teacher</FormerTitle>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+`
+
+const Name = styled(H1)`
+`;
+
+const Title = styled(H2)`
+  font-weight: 400;
+`;
+
+const FormerTitle = styled(H3)`
+  font-weight: 400;
+`;

--- a/frontend/src/components/ProfessionalPage/SideBar/Whoami.tsx
+++ b/frontend/src/components/ProfessionalPage/SideBar/Whoami.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   gap: 8px;
-`
+`;
 
 const Name = styled(H1)`
 `;


### PR DESCRIPTION
Add a new Whoami component to the sidebar displaying name and titles, improving personal branding on the professional page. Adjust the sidebar layout to use flex column with spacing for better alignment and spacing between Whoami and SideMenu. Update ProfessionalContent to reorder components for improved visual flow. Refine Biopic styling with justified text, line height, and indentation for better readability. Remove fixed width from SideMenu to allow flexible sizing within the layout.