### PR TITLE
Refactor title

### DIFF
--- a/frontend/src/components/Commons/Titles.tsx
+++ b/frontend/src/components/Commons/Titles.tsx
@@ -1,0 +1,13 @@
+import { styled } from 'styled-components';
+
+export const H1 = styled.h1`
+  font-size: 2.0rem;
+`;
+
+export const H2 = styled.h2`
+  font-size: 1.5rem;
+`;
+
+export const H3 = styled.h3`
+  font-size: 1.3rem;
+`;

--- a/frontend/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/frontend/src/components/GlobalStyles/GlobalStyles.tsx
@@ -18,6 +18,7 @@ const GlobalStyles = createGlobalStyle`
     font-family: "Lato", arial, sans-serif;
     font-weight: 400;
     font-style: normal;
+    font-size: 1.1rem;
   }
 
   .lato-thin {

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/AchievementsContainer.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/AchievementsContainer.tsx
@@ -20,19 +20,19 @@ export default function AchievementsContainer({achievements}: {achievements: str
   }
 
   return (
-        <AchievementWrapper>
-          <AchievementList>
-            {achievementsTag}
-          </AchievementList>
-          <RemainingAchievementWrapper>
-            {dropDown}
-          </RemainingAchievementWrapper>
-        </AchievementWrapper>
+    <AchievementWrapper>
+      <AchievementList>
+        {achievementsTag}
+      </AchievementList>
+      <RemainingAchievementWrapper>
+        {dropDown}
+      </RemainingAchievementWrapper>
+    </AchievementWrapper>
   );
 
 }
 
-const Arrow = styled(ArrowRight)`
+export const Arrow = styled(ArrowRight)`
   margin-top: 2px;
 `;
 

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/AchievementsDropDown.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/AchievementsDropDown.tsx
@@ -1,7 +1,6 @@
 import { styled } from 'styled-components';
 import { useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Arrow } from './AchievementsContainer';
 
 import { Achievement, AchievementList} from './AchievementsContainer';
 
@@ -11,7 +10,7 @@ export default function AchievementsDropDown({achievements}: {achievements: stri
   const achievementEntries = achievements
                                     .map((achievement, index) =>
                                       <Achievement key={index}>
-                                          <FontAwesomeIcon icon={faCircleChevronRight} />
+                                          <Arrow size={'1.4rem'}/>
                                           {achievement}
                                       </Achievement>
                                   );

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/Experience.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/Experience.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
 import ExperienceCard from './ExperienceCard';
-
+import { H1 } from 'components/Commons/Titles';
 import type { Experience } from './data.tsx';
 import EXPERIENCES from './data.tsx';
 
@@ -11,9 +11,12 @@ export default function Experience() {
   );
 
   return (
-    <ExperienceWrapper>
-      {experienceCards}
-    </ExperienceWrapper>
+    <Wrapper>
+      <H1>Resume</H1>
+      <ExperienceWrapper>
+        {experienceCards}
+      </ExperienceWrapper>
+    </Wrapper>
   );
 }
 
@@ -23,3 +26,11 @@ const ExperienceWrapper = styled.div`
   gap: 32px;
   margin: 0 auto;
 `;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: center;
+`;
+

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/ExperienceCard.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/Experience/ExperienceCard.tsx
@@ -1,5 +1,6 @@
 import { styled } from 'styled-components';
 
+import { H2 } from 'components/Commons/Titles';
 import type { Experience } from './data';
 import AchievementsContainer from './AchievementsContainer';
 
@@ -55,8 +56,7 @@ const Year = styled.span`
 `;
 
 
-const JobTitle = styled.h1`
-  font-size: 1.4rem;
+const JobTitle = styled(H2)`
 `;
 
 const TechList = styled.ul`

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/PortFolio/PortFolio.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/PortFolio/PortFolio.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import ProjectCard from './ProjectCard';
 
+import { H1 } from 'components/Commons/Titles';
 import PROJECTS from './FakeData';
 import type { Project } from './FakeData';
 
@@ -10,11 +11,21 @@ export default function PortFolio() {
     <ProjectCard key={project.id} project={project} />
   );
   return (
-    <ProjectCardWrapper>
-      { projects }
-    </ProjectCardWrapper>
+    <Wrapper>
+      <H1>Portfolio</H1>
+      <ProjectCardWrapper>
+        { projects }
+      </ProjectCardWrapper>
+      </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: center;
+`;
 
 const ProjectCardWrapper = styled.div`
   display: flex;

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/PortFolio/ProjectCard.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/PortFolio/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 
 import type { Project } from './FakeData';
+import { H2 } from 'components/Commons/Titles';
 
 export default function ProjectCard({project} : { project: Project }) {
   return (
@@ -46,7 +47,7 @@ const ProjectContent = styled.div`
   padding: 12px;
 `;
 
-const ProjectTitle = styled.div`
+const ProjectTitle = styled(H2)`
   text-align: center;
   font-size: 1.4rem;
 `;

--- a/frontend/src/components/ProfessionalPage/ProfessionalContent/ProfessionalContent.tsx
+++ b/frontend/src/components/ProfessionalPage/ProfessionalContent/ProfessionalContent.tsx
@@ -17,5 +17,6 @@ const Wrapper = styled.div`
   max-width: 700px;
   display: flex;
   flex-direction: column;
-  gap: 64px;
+  gap: 104px;
 `;
+

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "files": [],
-  "references": [
+"files": [],
+"references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+],
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import path from 'path'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      components: path.resolve(__dirname, 'src/components'),
+    }
+  }
 })


### PR DESCRIPTION
- Introduce reusable H1, H2, H3 styled components for consistent typography
- Add H1 titles "Resume" and "Portfolio" to Experience and PortFolio sections
- Wrap Experience and PortFolio content in centered flex containers for better layout
- Replace inline font sizes with H2 component in ExperienceCard for uniform styling
- Export Arrow icon from AchievementsContainer and use it in AchievementsDropDown
- Increase gap between sections in ProfessionalContent for improved spacing
- Add path alias for components in vite.config.ts to simplify imports
- Adjust global font size to 1.1rem for better readability

These changes enhance visual hierarchy, maintain styling consistency, and improve code maintainability.