### PR TITLE
refactor(api): update professional endpoint and frontend data flow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,20 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
+
+origins = [
+    "http://localhost:5173"
+]
 
 app = FastAPI()
 
-origins = [
-    "http://localhost:5173",
-]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 WHOAMI = {
         "name": "Emmanuel Guefif",
@@ -18,6 +27,12 @@ I like web development because it's the best way to solve people's problems. I a
     """
 }
 
-@app.get("/")
-async def whoami():
+class ProfessionalData(BaseModel):
+    name: str
+    title: str
+    catchPhrase: str
+    biopic: str
+
+@app.get("/professional/")
+async def professional():
     return WHOAMI

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "react-feather": "^2.0.10",
     "react-redux": "^9.2.0",
     "react-router": "^7.7.1",
-    "redux": "^5.0.1",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       react-router:
         specifier: ^7.7.1
         version: 7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      redux:
-        specifier: ^5.0.1
-        version: 5.0.1
       styled-components:
         specifier: ^6.1.19
         version: 6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)

--- a/frontend/src/components/ProfessionalPage/SideBar/SideBar.tsx
+++ b/frontend/src/components/ProfessionalPage/SideBar/SideBar.tsx
@@ -4,8 +4,9 @@ import { QUERIES } from 'components/constants';
 import SideMenu from './SideMenu';
 import SocialLinks from './SocialLinks';
 import Whoami from './Whoami';
+import type { User } from 'components/ProfessionalPage/useFetchuser'
 
-export default function SideBar({ user }) {
+export default function SideBar({ user }: {user: User}) {
   return (
       <SideBarWrapper>
         <Whoami user={user}/>

--- a/frontend/src/components/ProfessionalPage/useFetchUser.ts
+++ b/frontend/src/components/ProfessionalPage/useFetchUser.ts
@@ -17,7 +17,7 @@ const useFetchUser = () => {
     const fetchData = async () => {
       setLoading(true);
       try {  
-        const {data} = await axios.get('/api');
+        const {data} = await axios.get('/professional');
         setUserData(data);
       } catch(error) {
         console.error(error.message)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,14 +4,9 @@ import { RouterProvider } from 'react-router';
 
 import router from './router';
 
-import { Provider } from 'react-redux';
-import store from './store';
-
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-   <Provider store={store}>
-      <RouterProvider router={router} />
-    </Provider>
+    <RouterProvider router={router} />
   </StrictMode>
 )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,10 +11,9 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': {
+      '/professional': {
         target: 'http://127.0.0.1:8000',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
         configure: (proxy) => {
           proxy.on('proxyReq', (proxyReq, req) => {
             if (req.headers.origin) {


### PR DESCRIPTION
Remove redux dependency and related provider from the frontend to simplify state management. Change backend API path from "/" to "/professional" and add CORS middleware to allow requests from the frontend origin. Define a Pydantic model for professional data to enforce response schema. Update frontend API calls and proxy configuration to match the new endpoint. Adjust component typings accordingly. These changes improve API clarity, enable CORS, and streamline frontend architecture.